### PR TITLE
changed highlighter value from "none" to "rouge"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: '/rickshaw'
 title: 'Rickshaw'
 description: 'A group website thing.'
 permalink: 'pretty'
-highlighter: 'none'
+highlighter: 'rouge'
 exclude:
   - '.jekyll-cache'
   - 'Gemfile'


### PR DESCRIPTION
Maybe this will fix the error below:
-
The page build completed successfully, but returned the following warning for the `master` branch:

You are attempting to use the 'none' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/en/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#fixing-highlighting-errors.